### PR TITLE
Made flatten_string function private

### DIFF
--- a/phandler.py
+++ b/phandler.py
@@ -7,7 +7,7 @@ class prints_handler:
         self.ignore_errors = ignore_errors
         self.end = None
     
-    def flatten_string(self, args):
+    def _flatten_string(self, args):
         text = ''
         for i in range(len(args)):
             text += str(args[i]) + (' ' if i != len(args) - 1 else '')
@@ -19,7 +19,7 @@ class prints_handler:
         return value
 
     def print(self, *args, **kwargs):
-        text = self.flatten_string(args)
+        text = self._flatten_string(args)
 
         self.printing_array += text + (kwargs['end'] if 'end' in kwargs else '\n')
         if 'end' not in kwargs: print(text)


### PR DESCRIPTION
It looks like the flatten_string function is only intended for use by other members of the prints_handler class and not for being called externally. So, I made it private using the standard naming convention for private members (prefix with "_").